### PR TITLE
bin폴더와 application.properties를 gitignore에 추가함

### DIFF
--- a/bin/.gitignore
+++ b/bin/.gitignore
@@ -1,0 +1,37 @@
+HELP.md
+target/
+!.mvn/wrapper/maven-wrapper.jar
+!**/src/main/**/target/
+!**/src/test/**/target/
+
+### STS ###
+.apt_generated
+.classpath
+.factorypath
+.project
+.settings
+.springBeans
+.sts4-cache
+
+### IntelliJ IDEA ###
+.idea
+*.iws
+*.iml
+*.ipr
+
+### NetBeans ###
+/nbproject/private/
+/nbbuild/
+/dist/
+/nbdist/
+/.nb-gradle/
+build/
+!**/src/main/**/build/
+!**/src/test/**/build/
+
+### VS Code ###
+.vscode/
+
+/bin/
+/application.properties
+


### PR DESCRIPTION
bin폴더는 Eclipse에서 컴파일된 클래스 파일이 저장되는 폴더라 언제든지 재생성할 수 있는 파일들이기 때문에 Git에 포함할 필요가 없음

